### PR TITLE
add check if keyd is already installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,40 +15,44 @@ elif [ -f /usr/bin/apk ]; then
 	distro="alpine"
 fi
 
-echo "Installing keyd dependencies"
-case $distro in
-    deb)
-        sudo apt install -y build-essential git
-	;;
-    arch)
-	sudo pacman -S --noconfirm base-devel git
-	;;
-    fedora)
-	sudo dnf groupinstall -y "Development Tools" "Development Libraries"
-	;;
-esac
 
-echo "Installing keyd"
-case $distro in
-    suse)
-	sudo zypper --non-interactive install keyd
-	;;
-    arch)
-	git clone https://aur.archlinux.org/keyd.git
-	cd keyd
-	makepkg -si --noconfirm
-	;;
-    alpine)
-	doas apk add --no-interactive keyd
-	;;
-    *)
-        git clone https://github.com/rvaiya/keyd
-	cd keyd
-	make
-	sudo make install
-	cd ..
-        ;;
-esac
+if ! [ -f /usr/bin/keyd ]; then
+    # if keyd isnt installed
+	echo "Installing keyd dependencies"
+	case $distro in
+		deb)
+			sudo apt install -y build-essential git
+		;;
+		arch)
+		sudo pacman -S --noconfirm base-devel git
+		;;
+		fedora)
+		sudo dnf groupinstall -y "Development Tools" "Development Libraries"
+		;;
+	esac
+
+	echo "Installing keyd"
+	case $distro in
+		suse)
+		sudo zypper --non-interactive install keyd
+		;;
+		arch)
+		git clone https://aur.archlinux.org/keyd.git
+		cd keyd
+		makepkg -si --noconfirm
+		;;
+		alpine)
+		doas apk add --no-interactive keyd
+		;;
+		*)
+		git clone https://github.com/rvaiya/keyd
+		cd keyd
+		make
+		sudo make install
+		cd ..
+		;;
+	esac
+fi
 
 echo "Generating config"
 python3 cros-keyboard-map.py


### PR DESCRIPTION
This pr adds a check to see if keyd is already installed. If installed, skip to the config generation,

Also, should the zoom scancode be reported as f11 instead of zoom to offer more compatibility with more applications?