### PR TITLE
Fix Google Assistant key on Pixel devices

### DIFF
--- a/configs/61-eve-keyboard.hwdb
+++ b/configs/61-eve-keyboard.hwdb
@@ -1,3 +1,3 @@
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svnGoogle:pnEve:pvr*
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnGoogle:pn*:pvr*
  KEYBOARD_KEY_d8=leftmeta
 


### PR DESCRIPTION
Fixes WeirdTreeThing/cros-keyboard-map#11 for Atlas devices and probably Nocturne devices as well, presuming they follow the same scheme.