### PR TITLE
Fix for Fedora 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <h1 align="center">Utility to generate keyd configurations for use on Chromebooks</h1>
 
+Fix for Fedora 41
+
 # Instructions
-1.     git clone https://github.com/WeirdTreeThing/cros-keyboard-map
-2.     cd cros-keyboard-map
+1.     git clone https://github.com/SwagHrco/cros-keyboard-map-fedora41
+2.     cd cros-keyboard-map-fedora41
 3.     ./install.sh
 
 Thanks to rvaiya for creating [keyd](https://github.com/rvaiya/keyd).

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,14 @@ fi
 echo "Installing, this may take some time...."
 
 # Fedora with the terra repo (Ultramarine) has keyd packaged
-[ "$distro" = "fedora" ] && dnf4 info keyd -y&>> pkg.log && FEDORA_HAS_KEYD=1
+[ "$distro" = "fedora" ] && FEDORA_HAS_KEYD=1
+
+        if [ "$distro" = "fedora" ]; then
+            $privesc dnf install -y dnf-plugins-core &>> pkg.log
+            $privesc dnf copr enable -y alternateved/keyd &>> pkg.log
+            $privesc dnf install -y keyd &>> pkg.log
+        fi
+
 
 if ! [ -f /usr/bin/keyd ]; then
     # if keyd isnt installed


### PR DESCRIPTION
The script dose not work on Fedora 41 because keyd dependency is missing, solution is to install it trough a COPR repo listed on the keyd github page.