### PR TITLE
Added Void Linux Support + list of supported distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## List of supported distributions
 - Alpine
 - Arch Linux
-- ChimeraOS
+- Chimera Linux
 - Debian
 - Fedora
 - openSUSE

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <h1 align="center">Utility to generate keyd configurations for use on Chromebooks</h1>
 
 ## List of supported distributions
-- Ubuntu
+- Alpine
+- Arch Linux
 - Debian
 - Fedora
-- Arch Linux
-- Alpine
 - openSUSE
+- Ubuntu
 - Void Linux
 
 ### Instructions

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 <h1 align="center">Utility to generate keyd configurations for use on Chromebooks</h1>
 
-> [!WARNING]
-> This script is under construction and may be ready later.
+## List of supported distrobutions
+- Ubuntu
+- Debian
+- Fedora
+- Arch Linux
+- Alpine
+- openSUSE
+- Void Linux
 
-# Instructions
+### Instructions
 1.     git clone https://github.com/WeirdTreeThing/cros-keyboard-map
 2.     cd cros-keyboard-map
 3.     ./install.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Utility to generate keyd configurations for use on Chromebooks</h1>
 
-## List of supported distrobutions
+## List of supported distributions
 - Ubuntu
 - Debian
 - Fedora

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <h1 align="center">Utility to generate keyd configurations for use on Chromebooks</h1>
+>[!WARNING]
+> This script is under construction and may be ready later.
 
 # Instructions
 1.     git clone https://github.com/WeirdTreeThing/cros-keyboard-map

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## List of supported distributions
 - Alpine
 - Arch Linux
+- ChimeraOS
 - Debian
 - Fedora
 - openSUSE

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <h1 align="center">Utility to generate keyd configurations for use on Chromebooks</h1>
->[!WARNING]
+
+> [!WARNING]
 > This script is under construction and may be ready later.
 
 # Instructions

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# alpine, arch, and suse have packages
+# void, alpine, arch, and suse have packages
 # need to build on fedora (without terra) and debian/ubuntu
 
 ROOT=$(pwd)
@@ -20,6 +20,8 @@ elif [ -f /usr/bin/dnf4 ]; then
 	distro="fedora"
 elif [ -f /sbin/apk ]; then
 	distro="alpine"
+elif [ -f /bin/xbps-install ]; then
+    distro="void"
 elif grep 'ID=nixos' /etc/os-release; then
 	echo "NixOS is not supported by this script."
 	echo "Bailing out..."
@@ -59,6 +61,9 @@ if ! [ -f /usr/bin/keyd ]; then
 			;;
 		alpine)
 			$privesc apk add --no-interactive keyd &>> pkg.log
+			;;
+		void)
+		    $privesc xbps-install -S keyd -y &>> pkg.log
 			;;
 		*)
 			if [ "$FEDORA_HAS_KEYD" = "1" ]; then
@@ -108,6 +113,17 @@ case $distro in
 	else
         	$privesc rc-update add keyd
         	$privesc rc-service keyd restart
+	fi
+	;;
+	void)
+	if [ -f /usr/bin/sv ]; then
+	    $privesc ln -s /etc/sv/keyd /var/service
+		$privesc sv enable keyd
+		$privesc sv start keyd
+	else
+	       echo "This script can only be used for Void Linux using 'runit' init system. Other init system on Void Linux are currently unsupported."
+		   echo "I'M OUTTA HERE!"
+		   exit 1
 	fi
 	;;
     *)


### PR DESCRIPTION
I've added Void Linux support that uses the 'runit' init system and I would like to merge this to upstream and I've also added a list for supported distros.