### PR TITLE
Extend TTY switching support to F5-F6 (Ctrl+Alt+F1-F6)

### DIFF
--- a/cros-keyboard-map.py
+++ b/cros-keyboard-map.py
@@ -122,6 +122,33 @@ def get_functional_row(physmap, use_vivaldi, super_is_held, super_inverted):
 
     return result
 
+def get_tty_switching(physmap):
+    """Generate TTY switching mappings for all top row keys.
+
+    Dynamically generates Ctrl+Alt+F{n} mappings based on the actual physmap,
+    ensuring compatibility with all Chromebook keyboard layouts.
+    """
+    arch = get_arch()
+    if arch != "x86_64":
+        arch = "arm"
+
+    i = 0
+    result = ""
+
+    # Generate F-key mappings for inverted mode (F-keys by default)
+    for code in physmap:
+        i += 1
+        result += f"f{i} = C-A-f{i}\n"
+
+    # Generate Chrome key mappings for non-inverted mode (Chrome keys by default)
+    i = 0
+    for code in physmap:
+        i += 1
+        chrome_key = vivaldi_keys[arch][code]
+        result += f"{chrome_key} = C-A-f{i}\n"
+
+    return result
+
 def get_keyd_config(physmap, inverted):
     config = f"""\
 [ids]
@@ -157,24 +184,7 @@ down = pagedown
 
 [control+alt]
 backspace = C-A-delete
-# TTY switching for inverted mode (F-keys by default)
-f1 = C-A-f1
-f2 = C-A-f2
-f3 = C-A-f3
-f4 = C-A-f4
-f5 = C-A-f5
-f6 = C-A-f6
-f7 = C-A-f7
-f8 = C-A-f8
-# TTY switching for non-inverted mode (Chrome keys by default)
-back = C-A-f1
-forward = C-A-f2
-refresh = C-A-f3
-zoom = C-A-f4
-scale = C-A-f5
-brightnessdown = C-A-f6
-brightnessup = C-A-f7
-mute = C-A-f8
+{get_tty_switching(physmap)}
 """
     return config
 

--- a/cros-keyboard-map.py
+++ b/cros-keyboard-map.py
@@ -157,6 +157,24 @@ down = pagedown
 
 [control+alt]
 backspace = C-A-delete
+# TTY switching for inverted mode (F-keys by default)
+f1 = C-A-f1
+f2 = C-A-f2
+f3 = C-A-f3
+f4 = C-A-f4
+f5 = C-A-f5
+f6 = C-A-f6
+f7 = C-A-f7
+f8 = C-A-f8
+# TTY switching for non-inverted mode (Chrome keys by default)
+back = C-A-f1
+forward = C-A-f2
+refresh = C-A-f3
+zoom = C-A-f4
+scale = C-A-f5
+brightnessdown = C-A-f6
+brightnessup = C-A-f7
+mute = C-A-f8
 """
     return config
 


### PR DESCRIPTION
## Summary

This PR extends TTY switching support from F1-F4 to F1-F6 for Chromebook keyboards. Previously only Ctrl+Alt+F1-F4 worked; this adds F5-F6 support.

## Changes

Added key mappings in the `[control+alt]` section for both modes:

**Non-inverted mode (default behavior - Chrome keys):**
- Maps Chrome keys to TTY switches: back→F1, forward→F2, refresh→F3, zoom→F4, scale→F5, brightnessdown→F6, brightnessup→F7, mute→F8

**Inverted mode (`-i` flag - F-keys as default):**
- Maps F-keys directly to TTY switches: F1→F1, F2→F2, etc.

This ensures Ctrl+Alt+F1-F6 works in both configuration modes. F7-F8 are also mapped but typically unused since Linux defaults to 6 TTYs (they will work if additional TTYs are configured).

## Improvements

- **Extended range**: F1-F4 → F1-F6 (covers all standard Linux TTYs)
- **Better UX**: Can now hold Ctrl+Alt and switch between TTYs fluidly (e.g., 2→3→2) without releasing modifiers. Previously required pressing Ctrl+Alt for each switch.

## Use Case

TTY switching is essential for:
- Troubleshooting graphics or desktop environment issues
- Accessing recovery consoles when GUI fails
- Server management on Chromebook hardware
- Standard Linux workflow expectations

## Testing

Tested on Arch Linux + Hyprland with both keyboard configurations. TTY switching now works smoothly for F1-F6 with improved modifier key behavior.