### PR TITLE
ignore touchscreen device ID in keyboard map

### DIFF
--- a/cros-keyboard-map.py
+++ b/cros-keyboard-map.py
@@ -17,6 +17,7 @@ device_ids = {
     "k:18d1:5044", # Google Inc. Hammer
     "k:18d1:5061", # Google Inc. Hammer
     "k:18d1:502b", # Google Inc. Hammer
+    "-0000:0000:404212c6", # Elan Touchscreen
 }
 
 vivaldi_keys = {

--- a/cros-keyboard-map.py
+++ b/cros-keyboard-map.py
@@ -17,6 +17,8 @@ device_ids = {
     "k:18d1:5044", # Google Inc. Hammer
     "k:18d1:5061", # Google Inc. Hammer
     "k:18d1:502b", # Google Inc. Hammer
+}
+ignored_device_ids = {
     "-0000:0000:404212c6", # Elan Touchscreen
 }
 
@@ -61,6 +63,9 @@ def get_arch():
     return platform.uname().machine
 
 def get_ids_string(device_ids):
+    return "\n".join(device_ids)
+
+def get_ignored_ids_string(device_ids):
     return "\n".join(device_ids)
 
 def get_dt_layout():
@@ -153,6 +158,7 @@ def get_tty_switching(physmap):
 def get_keyd_config(physmap, inverted):
     config = f"""\
 [ids]
+{get_ids_string(ignored_device_ids)}
 {get_ids_string(device_ids)}
 
 [main]

--- a/cros-keyboard-map.py
+++ b/cros-keyboard-map.py
@@ -65,9 +65,6 @@ def get_arch():
 def get_ids_string(device_ids):
     return "\n".join(device_ids)
 
-def get_ignored_ids_string(device_ids):
-    return "\n".join(device_ids)
-
 def get_dt_layout():
     keys = []
     keycodes = []


### PR DESCRIPTION
I'm using a touchscreen chromebook with postmarketos. keyd 2.6.0 now creates a virtual pointer which messes with touch screen behavior if the touchscreen/touchpad device ID is included in the config files.

If I change the file to be more specific, using `k:0000:0000:af5c732c` (which is my `cros_ec` device ID) instead of just `k:0000:0000`, then it ignores the touchscreen by default:

```
$ sudo keyd
CONFIG: parsing /etc/keyd/default.conf
Starting keyd v2.6.0
DEVICE: ignoring 0000:0000:3511ce2b  (BlueZ 5.86 (MCS))
DEVICE: ignoring 0000:0000:ebeae809  (mtk-rt5650 Headset Jack)
WARNING: 04f3:009f:6a509ca1 appears to be a trackpad, which is current unsupported. Mouse movement is likely to break(YMMV)
DEVICE: ignoring 04f3:009f:6a509ca1  (Elan Touchpad)
WARNING: 0000:0000:404212c6 appears to be a trackpad, which is current unsupported. Mouse movement is likely to break(YMMV)
DEVICE: ignoring 0000:0000:404212c6  (Elan Touchscreen)
DEVICE: match    0001:0001:8ebcda3a  /etc/keyd/default.conf	(gpio-keys)
DEVICE: match    0000:0000:af5c732c  /etc/keyd/default.conf	(cros_ec)
```

However if every `cros_ec` device ID's third segment is different that makes it really hard to work for everyone.

I'm not sure what the solution is other than explicitly ignoring touchscreens by individual ID.

Also it only seems to work if the ignored device ID with "-" is above the other ones.