### PR TITLE
Fix sarien keyboard handling

### DIFF
--- a/configs/61-sarien-keyboard.hwdb
+++ b/configs/61-sarien-keyboard.hwdb
@@ -1,0 +1,4 @@
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnDellInc.:pn*:pvr*
+ KEYBOARD_KEY_d4=rightmeta
+ KEYBOARD_KEY_d5=zoom
+ KEYBOARD_KEY_d6=scale

--- a/configs/cros-sarien-inv.conf
+++ b/configs/cros-sarien-inv.conf
@@ -13,17 +13,20 @@ scrolldown = f6
 mute = f7
 volumedown = f8
 volumeup = f9
+switchvideomode = f12
 
 f1 = back 
 f2 = refresh
 f3 = zoom
 f4 = scale
-f5 = camera
-f6 = scrolldown
+f5 = brightnessdown
+f6 = brightnessup
 f7 = mute
 f8 = volumedown
 f9 = volumeup
 f12 = switchvideomode
+
+leftmeta = capslock
 
 [alt]
 camera = kbdillumdown

--- a/configs/cros-sarien-inv.conf
+++ b/configs/cros-sarien-inv.conf
@@ -1,0 +1,30 @@
+# Config for Sarien and its variant, Arcada
+[ids]
+# AT keyboard is device 0001:0001
+0001:0001
+
+[main]
+back = f1
+refresh = f2
+zoom = f3
+scale = f4
+camera = f5
+scrolldown = f6
+mute = f7
+volumedown = f8
+volumeup = f9
+
+f1 = back 
+f2 = refresh
+f3 = zoom
+f4 = scale
+f5 = camera
+f6 = scrolldown
+f7 = mute
+f8 = volumedown
+f9 = volumeup
+f12 = switchvideomode
+
+[alt]
+camera = kbdillumdown
+scrolldown = kbdillumup

--- a/configs/cros-sarien.conf
+++ b/configs/cros-sarien.conf
@@ -4,36 +4,14 @@
 0001:0001
 
 [main]
-back = back
-refresh = refresh
+# f3
 zoom = f11
-scale = scale
-print = print
+# f5
 camera = brightnessdown
-prog1 = brightnessup
-mute = mute
-volumedown = volumedown
-volumeup = volumeup
-sleep = coffee
-
-[meta]
-back = f1
-refresh = f2
-zoom = f3
-scale = f4
-camera = f5
-prog1 = f6
-mute = f7
-volumedown = f8
-volumeup = f9
-switchvideomode = f12
-
+# f6
+scrolldown = brightnessup
+leftmeta = capslock
 
 [alt]
-backspace = delete
-meta = capslock
 camera = kbdillumdown
-prog1 = kbdillumup
-
-[control+alt]
-backspace = C-A-delete
+scrolldown = kbdillumup

--- a/configs/cros-sarien.conf
+++ b/configs/cros-sarien.conf
@@ -4,12 +4,9 @@
 0001:0001
 
 [main]
-# f3
-zoom = f11
-# f5
 camera = brightnessdown
-# f6
 scrolldown = brightnessup
+
 leftmeta = capslock
 
 [alt]

--- a/install.sh
+++ b/install.sh
@@ -45,15 +45,15 @@ echo "Installing, this may take some time...."
 
 if ! which keyd &>/dev/null && [ "$distro" != "nixos" ] ; then
 	build_keyd=1
-  # if keyd isnt installed
+	# if keyd isnt installed
 
-  # Debian-based distros and Fedora don't have keyd in the repos, ask the user to compile it from source.
-  if [ "distro" = "fedora" ] && [ ! "$FEDORA_HAS_KEYD" = "1" ] || [ "$distro" = "deb" ]; then
-  	echo "This script can compile keyd for you or you can choose to get it from another source."
-  	printf "Compile keyd? (Y/n) "
-  	read -r COMPKEYD
+	# Debian-based distros and Fedora don't have keyd in the repos, ask the user to compile it from source.
+	if [ "$distro" = "fedora" ] && [ ! "$FEDORA_HAS_KEYD" = "1" ] || [ "$distro" = "deb" ]; then
+		echo "This script can compile keyd for you or you can choose to get it from another source."
+		printf "Compile keyd? (Y/n) "
+		read -r COMPKEYD
 		[[ $COMPKEYD =~ ^[Nn]$ ]] && build_keyd=0
-  fi
+	fi
 
 	if [ "$build_keyd" = "1" ]; then
 		echo "Installing keyd dependencies"
@@ -67,7 +67,7 @@ if ! which keyd &>/dev/null && [ "$distro" != "nixos" ] ; then
 		esac
 	fi
 
-	if ( [ "distro" = "fedora" ] && [ ! "$FEDORA_HAS_KEYD" = "1" ] || [ "$distro" = "deb" ] ) && [ "$build_keyd" = "1" ]; then
+	if ( [ "$distro" = "fedora" ] && [ ! "$FEDORA_HAS_KEYD" = "1" ] || [ "$distro" = "deb" ] ) && [ "$build_keyd" = "1" ]; then
 		echo "Compiling keyd"
 		git clone https://github.com/rvaiya/keyd &>> pkg.log
 		cd keyd
@@ -87,7 +87,7 @@ if ! which keyd &>/dev/null && [ "$distro" != "nixos" ] ; then
 				$privesc apk add --no-interactive keyd &>> pkg.log
 				;;
 			void)
-		  	$privesc xbps-install -S keyd -y &>> pkg.log
+				$privesc xbps-install -S keyd -y &>> pkg.log
 				;;
 			fedora)
 				$privesc dnf4 install -y keyd &>> pkg.log
@@ -107,7 +107,15 @@ then
 	$privesc udevadm trigger
 elif (grep -E "^(Sarien|Arcada)$" /sys/class/dmi/id/product_name &> /dev/null)
 then
-	cp -f configs/cros-sarien.conf cros.conf
+	$privesc mkdir -p /etc/udev/hwdb.d/
+	$privesc cp -f configs/61-sarien-keyboard.hwdb /etc/udev/hwdb.d/
+	$privesc udevadm hwdb --update
+	$privesc udevadm trigger
+	printf "By default, the top row keys will do their special function (brightness, volume, browser control, etc).\n"
+	printf "Holding the fn key will make the top row keys act like fn keys (f1, f2, f3, etc).\n"
+	printf "Would you like to invert this? (y/N) "
+	read -r INVERT
+	[[ $INVERT =~ ^[Yy]$ ]] && cp -f configs/cros-sarien-inv.conf cros.conf || cp -f configs/cros-sarien.conf cros.conf
 else
 	printf "By default, the top row keys will do their special function (brightness, volume, browser control, etc).\n"
 	printf "Holding the search key will make the top row keys act like fn keys (f1, f2, f3, etc).\n"
@@ -127,29 +135,29 @@ $privesc cp -f cros.conf /etc/keyd
 
 echo "Enabling keyd"
 case $distro in
-  alpine)
+	alpine)
 		# Chimera uses apk like alpine but uses dinit instead of openrc
 		if [ -f /usr/bin/dinitctl ]; then
 			$privesc dinitctl start keyd
 			$privesc dinitctl enable keyd
 		else
-      $privesc rc-update add keyd
-      $privesc rc-service keyd restart
+			$privesc rc-update add keyd
+			$privesc rc-service keyd restart
 		fi
 		;;
 	void)
 		if [ -f /usr/bin/sv ]; then
-	    $privesc ln -s /etc/sv/keyd /var/service
+			$privesc ln -s /etc/sv/keyd /var/service
 			$privesc sv enable keyd
 			$privesc sv start keyd
 		else
-	    echo "This script can only be used for Void Linux using 'runit' init system. Other init system on Void Linux are currently unsupported."
-		  echo "I'M OUTTA HERE!"
-		  exit 1
+			echo "This script can only be used for Void Linux using 'runit' init system. Other init system on Void Linux are currently unsupported."
+			echo "I'M OUTTA HERE!"
+			exit 1
 		fi
 		;;
-  *)
-    $privesc systemctl enable keyd
+	*)
+		$privesc systemctl enable keyd
 		$privesc systemctl restart keyd
 		;;
 esac
@@ -157,9 +165,9 @@ esac
 echo "Installing libinput configuration"
 $privesc mkdir -p /etc/libinput
 if [ -f /etc/libinput/local-overrides.quirks ]; then
-  cat $ROOT/local-overrides.quirks | $privesc tee -a /etc/libinput/local-overrides.quirks > /dev/null
+	cat $ROOT/local-overrides.quirks | $privesc tee -a /etc/libinput/local-overrides.quirks > /dev/null
 else
-  $privesc cp -f $ROOT/local-overrides.quirks /etc/libinput/local-overrides.quirks
+	$privesc cp -f $ROOT/local-overrides.quirks /etc/libinput/local-overrides.quirks
 fi
 
 echo "Done"


### PR DESCRIPTION
Also, include an inverted top row configuration, fixed a couple of indentation errors and some comparisons for the $distro variable.

Addresses issue #63.