### PR TITLE
Fix HP YAVIKS function key mapping

### DIFF
--- a/cros-keyboard-map.py
+++ b/cros-keyboard-map.py
@@ -36,7 +36,7 @@ vivaldi_keys = {
         "A0": "mute",
         "AE": "volumedown",
         "B0": "volumeup",
-        "DD": "sysrq",
+        "DD": "controlpanel",
         "E9": "forward",
         "EA": "back",
         "E7": "refresh",


### PR DESCRIPTION
Fixes sysrq duplication that caused the screenshot key to be mapped to F13 instead of F5. Control panel key (F13) remains dead because keyd doesn't handle the KEY_CONTROLPANEL event code.